### PR TITLE
Open submenu  when active

### DIFF
--- a/dist/js/main.js
+++ b/dist/js/main.js
@@ -100,6 +100,11 @@ $(function () {
 				e.preventDefault();
 			}
 		});
+
+		//open parent menus when child item is active
+		$(document).ready(function () {
+			$(menu).find('.treeview-menu li.active').parents('.treeview').addClass('active');
+       		 });
 	};
 
 	// Activate sidenav treemenu


### PR DESCRIPTION
Open submenus when child item is active (has "active" class).  I think that this is expected behavior for the menu deeper than one level.