### PR TITLE
Fix bootstrap-components.html

### DIFF
--- a/bootstrap-components.html
+++ b/bootstrap-components.html
@@ -447,35 +447,29 @@
             <div class="bs-component">
               <div>
                 <ul class="pagination">
-                  <li class="page-item disabled"><a class="page-link" href="#">«</a></li>
-                  <li class="page-item active"><a class="page-link" href="#">1</a></li>
-                  <li class="page-item"><a class="page-link" href="#">2</a></li>
-                  <li class="page-item"><a class="page-link" href="#">3</a></li>
-                  <li class="page-item"><a class="page-link" href="#">4</a></li>
-                  <li class="page-item"><a class="page-link" href="#">5</a></li>
-                  <li class="page-item"><a class="page-link" href="#">»</a></li>
+                  <li class="page-item disabled"><a class="page-link" href="#pagination">«</a></li>
+                  <li class="page-item active"><a class="page-link" href="#pagination">1</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">2</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">3</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">»</a></li>
                 </ul>
               </div>
               <div>
                 <ul class="pagination pagination-lg">
-                  <li class="page-item disabled"><a class="page-link" href="#">«</a></li>
-                  <li class="page-item active"><a class="page-link" href="#">1</a></li>
-                  <li class="page-item"><a class="page-link" href="#">2</a></li>
-                  <li class="page-item"><a class="page-link" href="#">3</a></li>
-                  <li class="page-item"><a class="page-link" href="#">4</a></li>
-                  <li class="page-item"><a class="page-link" href="#">5</a></li>
-                  <li class="page-item"><a class="page-link" href="#">»</a></li>
+                  <li class="page-item disabled"><a class="page-link" href="#pagination">«</a></li>
+                  <li class="page-item active"><a class="page-link" href="#pagination">1</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">2</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">3</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">»</a></li>
                 </ul>
               </div>
               <div>
                 <ul class="pagination pagination-sm">
-                  <li class="page-item disabled"><a class="page-link" href="#">«</a></li>
-                  <li class="page-item active"><a class="page-link" href="#">1</a></li>
-                  <li class="page-item"><a class="page-link" href="#">2</a></li>
-                  <li class="page-item"><a class="page-link" href="#">3</a></li>
-                  <li class="page-item"><a class="page-link" href="#">4</a></li>
-                  <li class="page-item"><a class="page-link" href="#">5</a></li>
-                  <li class="page-item"><a class="page-link" href="#">»</a></li>
+                  <li class="page-item disabled"><a class="page-link" href="#pagination">«</a></li>
+                  <li class="page-item active"><a class="page-link" href="#pagination">1</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">2</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">3</a></li>
+                  <li class="page-item"><a class="page-link" href="#pagination">»</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Mobile page breaks because `.pagination-lg` overflows. Fixed by removing some links. Links also lead to `#pagination` instead of going to the top of the page.