### PR TITLE
Updating link to fontawesome icons

### DIFF
--- a/src/pug/includes/_sidebar.pug
+++ b/src/pug/includes/_sidebar.pug
@@ -24,7 +24,7 @@ aside.app-sidebar
 						i.icon.fa.fa-circle-o
 						|  Bootstrap Elements
 				li
-					a.treeview-item(href='http://fontawesome.io/icons/', target="_blank", rel="noopener")
+					a.treeview-item(href='https://fontawesome.com/v4.7.0/icons/', target="_blank", rel="noopener")
 						i.icon.fa.fa-circle-o
 						|  Font Icons
 				li


### PR DESCRIPTION
The link should redirect the user to the icons for version 4.7.0 and not the newest 5.0.8.
This makes sure that there are no misunderstandings on which icons can be used.