### PR TITLE
Include vendor libraries from npm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,9 @@ module.exports = function(grunt) {
 			dist: {
 				options: {
 					outputStyle: 'expanded',
-					sourceMap: false
+					sourceMap: false,
+					implementation : 'node-sass',
+					includePaths : ['node_modules']
 				},
 				files: [{
 					expand: true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "grunt-contrib-pug": "^1.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.8.0",
-    "grunt-sass": "^2.1.0"
+    "grunt-sass": "^2.1.0",
+    "node-sass": "^4.11.0"
   },
   "scripts": {
     "dev": "grunt watch",


### PR DESCRIPTION
This commit adds feature to let npm manage bootstrap source and third party libraries instead of committing them directly in to this project.

We can include bootstrap source from bootstrap/scss/bootstrap and its version is managed from package.json. The same can be done with pace, sweetalert2, datatables etc.,

That way, the dependencies in this project can be easily upgraded in future.